### PR TITLE
Modify `BertTokenizer`

### DIFF
--- a/Sources/BertTokenizer.swift
+++ b/Sources/BertTokenizer.swift
@@ -106,13 +106,13 @@ class BasicTokenizer {
     func tokenize(text: String) -> [String] {
         let splitTokens = text.folding(options: .diacriticInsensitive, locale: nil)
             .components(separatedBy: NSCharacterSet.whitespaces)
-        let tokens = splitTokens.flatMap({ (token: String) -> [String] in
+        var tokens = splitTokens.flatMap({ (token: String) -> [String] in
             if neverSplit.contains(token) {
                 return [token]
             }
             var toks: [String] = []
             var currentTok = ""
-            for c in token.lowercased() {
+            for c in token {
                 if c.isLetter || c.isNumber || c == "°" {
                     currentTok += String(c)
                 } else if currentTok.count > 0 {
@@ -128,6 +128,14 @@ class BasicTokenizer {
             }
             return toks
         })
+	var isFirst = true
+	tokens = tokens.map {
+	    defer { isFirst = false }
+	    if isFirst {
+		return $0
+	    }
+	    return " \($0)"
+	}
         return tokens
     }
 }


### PR DESCRIPTION
When I use `BertTokenizer` I felt some points needs to be modified.

### missing whitespace to each token.

After spliting texts by whitespace ` `, subsequential components are missing ` `.

Example Input : `Hello, I like dog.`
Actual tokens : ["Hello", "I", "like", "dog"]
Expected tokens in my case : ["Hello", " I", " like", " dog"]  

### force to be lowercase

All of inputs are converted into `lowercased` but I guess this behavior might not be correct (depends on `vocab.json`).


I fixed above two things. please correct or close this PR if I am wrong.